### PR TITLE
docs: fix typo AWS083

### DIFF
--- a/_docs/aws/AWS083.md
+++ b/_docs/aws/AWS083.md
@@ -9,7 +9,7 @@ permalink: /docs/aws/AWS083/
 
 Passing unknown or invalid headers through to the target poses a potential risk of compromise. 
 
-By setting drop_invalid_header_fields to true, anything that doe not conform to well known, defined headers will be removed by the load balancer.
+By setting drop_invalid_header_fields to true, anything that does not conform to well known, defined headers will be removed by the load balancer.
 
 
 


### PR DESCRIPTION
Hi 👋 , I was reading https://tfsec.dev/docs/aws/AWS083/ and found a typo.